### PR TITLE
#17 - Fixing StepOver when it is the end of a PERFORM execution

### DIFF
--- a/src/mi2.ts
+++ b/src/mi2.ts
@@ -362,16 +362,9 @@ export class MI2 extends EventEmitter implements IDebugger {
 			this.log("stderr", "stepOver");
 		return new Promise((resolve, reject) => {
 			this.sendCommand("stack-info-frame").then((result) => {
-				let map = this.map.getNextStep(result.result('frame.fullname'), parseInt(result.result('frame.line')));
-				if (map !== null) {
-					this.sendCommand('exec-until "' + escape(map.fileC) + ':' + map.lineC + '"').then((info) => {
-						resolve(info.resultRecords.resultClass == "running");
-					}, reject);
-				} else {
-					this.sendCommand("exec-next").then((info) => {
-						resolve(info.resultRecords.resultClass == "running");
-					}, reject);
-				}
+				this.sendCommand("exec-next").then((info) => {
+					resolve(info.resultRecords.resultClass == "running");
+				}, reject);
 			});
 		});
 	}


### PR DESCRIPTION
@OlegKunitsyn  I hope you don't mind these changes.

PERFORM is a GOTO operation, which means the sourceMap is not pointing to the proper next line when the paragraph comes to the end. And GDB is handling correctly the next source line break command (-exec-next), moving back the previous paragraph.