### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
   <br>
     <img src="https://github.com/OlegKunitsyn/gnucobol-debug/blob/master/icon.png?raw=true" alt="logo" width="200">
   <br>
-  VS Code Debugger for GnuCOBOL
+  Debugger for GnuCOBOL
   <br>
   <br>
 </h1>
 
-<h4 align="center">Debug COBOL code from VS Code.</h4>
+<h4 align="center">Debug COBOL code from any vscode based editor.</h4>
 
 <p align="center">
   <a href="https://marketplace.visualstudio.com/items?itemName=OlegKunitsyn.gnucobol-debug"><img src="https://vsmarketplacebadge.apphb.com/version/OlegKunitsyn.gnucobol-debug.svg?label=Debugger%20for%20GnuCOBOL" /></a>
@@ -15,7 +15,7 @@
   <a href="https://marketplace.visualstudio.com/items?itemName=OlegKunitsyn.gnucobol-debug"><img src="https://vsmarketplacebadge.apphb.com/installs-short/OlegKunitsyn.gnucobol-debug.svg?label=Installs" /></a>
 </p>
 
-A VS Code extension to debug or execute GnuCOBOL code. [Install from VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=OlegKunitsyn.gnucobol-debug).
+An extension to debug or execute GnuCOBOL code in any [vscode](https://github.com/Microsoft/vscode/) based editors like [VSCodium](https://vscodium.com/) or [Microsoft Visual Studio Code](https://code.visualstudio.com/).
 
 ### Features
 * Setting breakpoints
@@ -28,7 +28,7 @@ A VS Code extension to debug or execute GnuCOBOL code. [Install from VS Code Mar
 ![Screenshot](screenshot.png)
 
 ### Requirements
-A COBOL-syntax extension i.e. `ibm.zopeneditor`, `broadcommfd.cobol-language-support`, `rechinformatica.rech-editor-cobol` or `bitlang.cobol` installed. Otherwise, the breakpoints will be unavailable. 
+A COBOL-syntax extension i.e. [`bitlang.cobol`](https://open-vsx.org/extension/bitlang/cobol), `ibm.zopeneditor`, `broadcommfd.cobol-language-support`, or `rechinformatica.rech-editor-cobol` installed. Otherwise, the breakpoints will be unavailable. 
 
 Now you may choose between *local* and *container* execution environment. Or try both of them :)
 


### PR DESCRIPTION
* removed all direct references to the "product" Visual Studio Code but one
* referenced vscode (the repository) once
* blatantly included a reference to VSCodium
* moved the COBOL extension that is not mainframe centric up-front, including a link to install it