### PR TITLE
#35 - Fixing WATCH and HOVER modes during expression evaluation

### DIFF
--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -361,7 +361,7 @@ export class GDBDebugSession extends DebugSession {
 		} else if (typeof id == "string") {
 			try {
 				// TODO: this evals on an (effectively) unknown thread for multithreaded programs.
-				const stackVariable = await this.miDebugger.evalExpression(id, 0, 0);
+				const stackVariable = await this.miDebugger.evalCobField(id, 0, 0);
 
 				const variables: DebugProtocol.Variable[] = [];
 				variables.push({
@@ -439,7 +439,7 @@ export class GDBDebugSession extends DebugSession {
 			this.miDebugger.evalExpression(args.expression, threadId, level).then((res) => {
 				response.body = {
 					variablesReference: 0,
-					result: res.value || "null"
+					result: res || "not available"
 				};
 				this.sendResponse(response);
 			}, msg => {

--- a/src/mi2.ts
+++ b/src/mi2.ts
@@ -658,7 +658,7 @@ export class MI2 extends EventEmitter implements IDebugger {
 		const functionName = await this.getCurrentFunctionName();
 
 		if (this.verbose)
-			this.log("stderr", "evalVariable");
+			this.log("stderr", "evalExpression");
 
 		try {
 			const variable = this.map.findVariableByCobol(functionName, name);
@@ -678,7 +678,7 @@ export class MI2 extends EventEmitter implements IDebugger {
 		const functionName = await this.getCurrentFunctionName();
 
 		if (this.verbose)
-			this.log("stderr", "expandField");
+			this.log("stderr", "evalCobField");
 
 		try {
 			const variable = this.map.getVariableByCobol(`${functionName}.${name}`);

--- a/src/mi2.ts
+++ b/src/mi2.ts
@@ -771,9 +771,8 @@ export class MI2 extends EventEmitter implements IDebugger {
 				resolve(node);
 			};
 			this.stdin(
-				`call (void)fprintf(stdout, \"${sel}^done,value=\\\"\")
-				 call (void)display_common(&${cName},stdout)
-				 call (void)fprintf(stdout, \"\\\"\\n\")\ncall fflush(stdout)`);
+				`call (void)fprintf(stdout, \"${sel}^done,value=|")
+				 call (void)cob_display(0,1,1,&${cName})`);
 		});
 	}
 

--- a/src/parser.c.ts
+++ b/src/parser.c.ts
@@ -142,6 +142,15 @@ export class SourceMap {
 		return null;
 	}
 
+	public findVariableByCobol(functionName: string, name: string): DebuggerVariable {
+		for (const key of this.variablesByCobol.keys()) {
+			if (key.startsWith(functionName) && key.endsWith(`.${name}`)) {
+				return this.variablesByCobol.get(key);
+			}
+		}
+		return null;
+	}
+
 	public getVariableByCobol(path: string): DebuggerVariable {
 		return this.variablesByCobol.get(path);
 	}

--- a/src/parser.c.ts
+++ b/src/parser.c.ts
@@ -7,7 +7,7 @@ const attributeRegex = /static\sconst\scob_field_attr\s(a_[0-9]+).*\{(0x\d+),\s*
 const dataStorageRegex = /static\s+(.*)\s+(b_[0-9]+)[;\[].*\/\*\s+([0-9a-z_\-]+)\s+\*\//i;
 const fieldRegex = /static\s+cob_field\s+([0-9a-z_]+)\s+\=\s+\{(\d+)\,\s+([0-9a-z_]+).+\&(a_\d+).*\/\*\s+([0-9a-z_\-]+)\s+\*\//i;
 const fileIncludeRegex = /#include\s+\"([0-9a-z_\-\.\s]+)\"/i;
-const fileCobolRegex = /\/\*\sGenerated from.*[\/\\]([0-9a-z_\-\/\.\s\\:]+)\s+\*\//i;
+const fileCobolRegex = /\/\*\sGenerated from\s+([0-9a-z_\-\/\.\s\\:]+)\s+\*\//i;
 const functionRegex = /\/\*\sProgram\slocal\svariables\sfor\s'(.*)'\s\*\//i;
 
 export class Line {

--- a/src/parser.mi2.ts
+++ b/src/parser.mi2.ts
@@ -189,6 +189,12 @@ export function parseMI(output: string): MINode {
 		return str;
 	};
 
+	const parseCobFieldValue = () => {
+		if (output[0] != '|')
+			return "";
+		return output.substr(1);
+	};
+
 	let parseValue, parseCommaResult, parseCommaValue, parseResult;
 
 	const parseTupleOrList = () => {
@@ -231,6 +237,8 @@ export function parseMI(output: string): MINode {
 			return parseCString();
 		else if (output[0] == '{' || output[0] == '[')
 			return parseTupleOrList();
+		else if (output[0] == '|')
+			return parseCobFieldValue();
 		else
 			return undefined;
 	};

--- a/test/parser.c.test.ts
+++ b/test/parser.c.test.ts
@@ -49,6 +49,15 @@ suite("C code parse", () => {
 		assert.equal('WS-BILL', parsed.getVariableByC('petstore_.b_14').cobolName);
 		assert.equal('TOTAL-QUANTITY', parsed.getVariableByC('petstore_.f_15').cobolName);
 	});
+	test("Find variables by function and COBOL name", () => {
+		const c = nativePath.resolve(cwd, 'petstore.c');
+		const parsed = new SourceMap(cwd, [c]);
+
+		assert.equal('f_15', parsed.findVariableByCobol('petstore_', 'TOTAL-QUANTITY').cName);
+		assert.equal('f_15', parsed.findVariableByCobol('petstore_', 'WS-BILL.TOTAL-QUANTITY').cName);
+		assert.equal(null, parsed.findVariableByCobol('petstore_', 'BLABLABLA'));
+		assert.equal(null, parsed.findVariableByCobol('blablaba_', 'WS-BILL.TOTAL-QUANTITY'));
+	});
 	test("Attributes", () => {
 		const c = nativePath.resolve(cwd, 'datatypes.c');
 		const parsed = new SourceMap(cwd, [c]);

--- a/test/parser.mi2.test.ts
+++ b/test/parser.mi2.test.ts
@@ -190,4 +190,9 @@ suite("MI Parse", () => {
 		assert.deepEqual(undefined, MINode.valueOf(variables[0], "value"));
 		assert.deepEqual('unsigned char [3]', MINode.valueOf(variables[0], "type"));
 	});
+	test("parse special cob_display event", () => {
+		const parsed = parseMI(`12^done,value=|blablabla`);
+		const value = parsed.result('value');
+		assert.equal('blablabla', value);
+	});
 });


### PR DESCRIPTION
If we add a variable to WATCH panel or when we are hovering over a variable, we are expecting to get a variable value, however, the variable may not be found, either for being out of the scope of the current function or because it doesn't exist. 

In these two situations, we should present a meaningful message instead of an exception.

In the current PR, when that happens, the extension is returning 'not available', which is the same default message replied by VSCode, when the debugger is not running.