### PR TITLE
#44 - expressions support

### DIFF
--- a/src/mi2.ts
+++ b/src/mi2.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from "events";
 import { MINode, parseMI } from './parser.mi2';
 import * as nativePath from "path";
 import { SourceMap } from "./parser.c";
-import { parseExpression } from "./parser.expression";
+import { parseExpression, replaceStartingZeroes } from "./parser.expression";
 
 const nonOutput = /(^(?:\d*|undefined)[\*\+\-\=\~\@\&\^])([^\*\+\-\=\~\@\&\^]{1,})/;
 const gdbRegex = /(?:\d*|undefined)\(gdb\)/;
@@ -668,7 +668,8 @@ export class MI2 extends EventEmitter implements IDebugger {
 				const variable = this.map.getVariableByC(`${functionName}.${variableName}`);
 				if (variable) {
 					await this.evalVariable(variable, thread, frame);
-					finalExpression = `const ${variableName}=${variable.value};` + finalExpression;
+					const value = replaceStartingZeroes(variable.value);
+					finalExpression = `const ${variableName}=${value};` + finalExpression;
 				}
 			}
 			return eval(finalExpression);

--- a/src/mi2.ts
+++ b/src/mi2.ts
@@ -674,7 +674,7 @@ export class MI2 extends EventEmitter implements IDebugger {
 			}
 			return eval(finalExpression);
 		} catch (e) {
-			this.log("stderr", `Failed to find ${expression}`);
+			this.log("stderr", `Failed to evaluate ${expression}`);
 			this.log("stderr", e.message);
 			throw e;
 		}

--- a/src/parser.expression.ts
+++ b/src/parser.expression.ts
@@ -3,6 +3,24 @@ import { SourceMap } from "./parser.c";
 const number = /[0-9]/;
 const numberOrChar = /[a-z0-9]/i;
 const containsCharacter = /(?=.*[a-zA-Z]).*/;
+const containsStartingZeroes = /^[-+]{0,1}0+/;
+
+export function replaceStartingZeroes(value: string): string {
+    if (!value || value.startsWith("0x") || value.startsWith("\"")) {
+        return value;
+    }
+    const negativeSign = value.startsWith("-") ? value.charAt(0) : "";
+    if (containsStartingZeroes.test(value)) {
+        let fixedValue = value.replace(containsStartingZeroes, "");
+
+        if (fixedValue.length === 0 || fixedValue.startsWith(".")) {
+            fixedValue = "0" + fixedValue;
+        }
+
+        return negativeSign + fixedValue;
+    }
+    return value;
+}
 
 function checkToken(token: string, tokenStack: string[], functionName: string, sourceMap: SourceMap, variablesInC: Set<string>): string {
     if (token.length === 0) {
@@ -29,6 +47,8 @@ function checkToken(token: string, tokenStack: string[], functionName: string, s
                 variableName = variableName.substring(0, position);
             }
         } while (position !== -1);
+    } else {
+        token = replaceStartingZeroes(token);
     }
     tokenStack.push(token);
     return "";

--- a/src/parser.expression.ts
+++ b/src/parser.expression.ts
@@ -4,21 +4,40 @@ const number = /[0-9]/;
 const numberOrChar = /[a-z0-9]/i;
 const containsCharacter = /(?=.*[a-zA-Z]).*/;
 
-function checkToken(token: string, tokenStack: string[], sourceMap: SourceMap): string {
+function checkToken(token: string, tokenStack: string[], functionName: string, sourceMap: SourceMap, variablesInC: Set<string>): string {
     if (token.length === 0) {
         return "";
     }
 
     if (containsCharacter.test(token)) {
-        //TODO - Fetch variable
-        console.log(`${token} is an identifier!`);
+        let position = -1;
+        let variableName = token;
+        do {
+            const variable = sourceMap.findVariableByCobol(functionName, variableName);
+            if (variable) {
+                variablesInC.add(variable.cName);
+                tokenStack.push(variable.cName);
+                if (position !== -1) {
+                    tokenStack.push(token.substring(position));
+                }
+                return "";
+            }
+
+            position = variableName.lastIndexOf(".", position);
+
+            if (position !== -1) {
+                variableName = variableName.substring(0, position);
+            }
+        } while (position !== -1);
     }
     tokenStack.push(token);
     return "";
 }
 
-export function parseExpression(expression: string, sourceMap: SourceMap): string {
+export function parseExpression(expression: string, functionName: string, sourceMap: SourceMap): [string, string[]] {
     const tokenStack: string[] = [];
+    const variableInC: Set<string> = new Set();
+
     let token = "";
     let openQuote = false;
     let quoteMarker = null;
@@ -29,25 +48,28 @@ export function parseExpression(expression: string, sourceMap: SourceMap): strin
             if (char === quoteMarker) {
                 tokenStack.push(token);
                 openQuote = false;
+                token = "";
             }
             continue;
         }
         switch (char) {
-            case '\s':
+            case ' ':
             case '\t':
             case '\n':
+                token = checkToken(token, tokenStack, functionName, sourceMap, variableInC);
                 continue;
             case '\'':
             case '"':
                 quoteMarker = char;
                 token += char;
                 openQuote = true;
+                continue;
             case '(':
             case ')':
             case '/':
             case '*':
             case ',':
-                token = checkToken(token, tokenStack, sourceMap);
+                token = checkToken(token, tokenStack, functionName, sourceMap, variableInC);
                 tokenStack.push(char);
                 continue;
             case '+':
@@ -55,7 +77,7 @@ export function parseExpression(expression: string, sourceMap: SourceMap): strin
                     token += char;
                     continue;
                 }
-                token = checkToken(token, tokenStack, sourceMap);
+                token = checkToken(token, tokenStack, functionName, sourceMap, variableInC);
                 tokenStack.push(char);
                 continue;
             case '-':
@@ -63,13 +85,13 @@ export function parseExpression(expression: string, sourceMap: SourceMap): strin
                     token += char;
                     continue;
                 }
-                token = checkToken(token, tokenStack, sourceMap);
+                token = checkToken(token, tokenStack, functionName, sourceMap, variableInC);
                 tokenStack.push(char);
                 continue;
             default:
                 token += char;
         }
     }
-    checkToken(token, tokenStack, sourceMap);
-    return tokenStack.join(" ");
+    checkToken(token, tokenStack, functionName, sourceMap, variableInC);
+    return [tokenStack.join(" "), Array.from(variableInC)];
 }

--- a/src/parser.expression.ts
+++ b/src/parser.expression.ts
@@ -23,7 +23,7 @@ function checkToken(token: string, tokenStack: string[], functionName: string, s
                 return "";
             }
 
-            position = variableName.lastIndexOf(".", position);
+            position = variableName.lastIndexOf(".");
 
             if (position !== -1) {
                 variableName = variableName.substring(0, position);

--- a/src/parser.expression.ts
+++ b/src/parser.expression.ts
@@ -1,0 +1,75 @@
+import { SourceMap } from "./parser.c";
+
+const number = /[0-9]/;
+const numberOrChar = /[a-z0-9]/i;
+const containsCharacter = /(?=.*[a-zA-Z]).*/;
+
+function checkToken(token: string, tokenStack: string[], sourceMap: SourceMap): string {
+    if (token.length === 0) {
+        return "";
+    }
+
+    if (containsCharacter.test(token)) {
+        //TODO - Fetch variable
+        console.log(`${token} is an identifier!`);
+    }
+    tokenStack.push(token);
+    return "";
+}
+
+export function parseExpression(expression: string, sourceMap: SourceMap): string {
+    const tokenStack: string[] = [];
+    let token = "";
+    let openQuote = false;
+    let quoteMarker = null;
+    for (let i = 0; i < expression.length; i++) {
+        let char = expression[i];
+        if (openQuote) {
+            token += char;
+            if (char === quoteMarker) {
+                tokenStack.push(token);
+                openQuote = false;
+            }
+            continue;
+        }
+        switch (char) {
+            case '\s':
+            case '\t':
+            case '\n':
+                continue;
+            case '\'':
+            case '"':
+                quoteMarker = char;
+                token += char;
+                openQuote = true;
+            case '(':
+            case ')':
+            case '/':
+            case '*':
+            case ',':
+                token = checkToken(token, tokenStack, sourceMap);
+                tokenStack.push(char);
+                continue;
+            case '+':
+                if (number.test(expression[i + 1])) {
+                    token += char;
+                    continue;
+                }
+                token = checkToken(token, tokenStack, sourceMap);
+                tokenStack.push(char);
+                continue;
+            case '-':
+                if (numberOrChar.test(expression[i - 1]) || numberOrChar.test(expression[i + 1])) {
+                    token += char;
+                    continue;
+                }
+                token = checkToken(token, tokenStack, sourceMap);
+                tokenStack.push(char);
+                continue;
+            default:
+                token += char;
+        }
+    }
+    checkToken(token, tokenStack, sourceMap);
+    return tokenStack.join(" ");
+}

--- a/test/parser.expression.test.ts
+++ b/test/parser.expression.test.ts
@@ -46,4 +46,29 @@ suite("WATCH expression parse", () => {
         assert.equal(actual, expected);
         assert.deepEqual(variables, ["f_15", "f_16"]);
     });
+    test("it removes zeroes from the beggining of a positive value", () => {
+        const [actual] = parseExpression("+000022", functionName, parsed);
+        const expected = "22";
+        assert.equal(actual, expected);
+    });
+    test("it removes zeroes from the beggining of a negative value", () => {
+        const [actual] = parseExpression("-000022", functionName, parsed);
+        const expected = "-22";
+        assert.equal(actual, expected);
+    });
+    test("it works for +0000.1234", () => {
+        const [actual] = parseExpression("+0000.1234", functionName, parsed);
+        const expected = "0.1234";
+        assert.equal(actual, expected);
+    });
+    test("it works for -0000.1234", () => {
+        const [actual] = parseExpression("-0000.1234", functionName, parsed);
+        const expected = "-0.1234";
+        assert.equal(actual, expected);
+    });
+    test("it works for 0", () => {
+        const [actual] = parseExpression("0", functionName, parsed);
+        const expected = "0";
+        assert.equal(actual, expected);
+    });
 });

--- a/test/parser.expression.test.ts
+++ b/test/parser.expression.test.ts
@@ -42,7 +42,7 @@ suite("WATCH expression parse", () => {
     });
     test("it parses complex expressions", () => {
         const [actual, variables] = parseExpression("\"TOTAL-QUANTITY*TOTAL-QUANTITY\".substring(0,1) + ((2*TOTAL-QUANTITY) - TOTAL-QUANTITY + WS-BILL.TOTAL-COST.length) + (TOTAL-COST.toLowerCase()) + WS-BILL.TOTAL-QUANTITY", functionName, parsed);
-        const expected = "\"TOTAL-QUANTITY*TOTAL-QUANTITY\" .substring ( 0 , 1 ) + ( ( 2 * f_15 ) - f_15 + f_16.length ) + ( f_16.toLowerCase ( ) ) + f_15";
+        const expected = "\"TOTAL-QUANTITY*TOTAL-QUANTITY\" .substring ( 0 , 1 ) + ( ( 2 * f_15 ) - f_15 + f_16 .length ) + ( f_16 .toLowerCase ( ) ) + f_15";
         assert.equal(actual, expected);
         assert.deepEqual(variables, ["f_15", "f_16"]);
     });

--- a/test/parser.expression.test.ts
+++ b/test/parser.expression.test.ts
@@ -1,0 +1,26 @@
+import * as assert from 'assert';
+import { SourceMap } from '../src/parser.c';
+import { parseExpression } from '../src/parser.expression';
+
+suite("WATCH expression parse", () => {
+    test("it can parse expressions", () => {
+        const actual = parseExpression("WXSS-AS*3", null);
+        const expected = "WXSS-AS * 3";
+        assert.equal(actual, expected);
+    });
+    test("multiple identifiers", () => {
+        const actual = parseExpression("WXSS-AS*WXSS-AS", null);
+        const expected = "WXSS-AS * WXSS-AS";
+        assert.equal(actual, expected);
+    });
+    test("only literals", () => {
+        const actual = parseExpression("444.32 - 2232.43", null);
+        const expected = "444.32 - 2232.43";
+        assert.equal(actual, expected);
+    });
+    test("it doesn't parse string values", () => {
+        const actual = parseExpression("\"WXSS-AS*WXSS-AS\".substring(0,1)", null);
+        const expected = "\"WXSS-AS*WXSS-AS\" .substring ( 0 , 1 )";
+        assert.equal(actual, expected);
+    });
+});

--- a/test/parser.expression.test.ts
+++ b/test/parser.expression.test.ts
@@ -1,26 +1,49 @@
 import * as assert from 'assert';
+import * as nativePath from "path";
 import { SourceMap } from '../src/parser.c';
 import { parseExpression } from '../src/parser.expression';
 
 suite("WATCH expression parse", () => {
+    const cwd = nativePath.resolve(__dirname, '../../test/resources');
+    const c = nativePath.resolve(cwd, 'petstore.c');
+    const parsed = new SourceMap(cwd, [c]);
+    console.log(parsed.toString());
+    const functionName = "petstore_";
+
     test("it can parse expressions", () => {
-        const actual = parseExpression("WXSS-AS*3", null);
-        const expected = "WXSS-AS * 3";
+        const [actual, variables] = parseExpression("TOTAL-QUANTITY*3", functionName, parsed);
+        const expected = "f_15 * 3";
         assert.equal(actual, expected);
+        assert.deepEqual(variables, ["f_15"]);
     });
     test("multiple identifiers", () => {
-        const actual = parseExpression("WXSS-AS*WXSS-AS", null);
-        const expected = "WXSS-AS * WXSS-AS";
+        const [actual, variables] = parseExpression("TOTAL-QUANTITY*TOTAL-QUANTITY", functionName, parsed);
+        const expected = "f_15 * f_15";
         assert.equal(actual, expected);
+        assert.deepEqual(variables, ["f_15"]);
     });
     test("only literals", () => {
-        const actual = parseExpression("444.32 - 2232.43", null);
+        const [actual, variables] = parseExpression("444.32 - 2232.43", functionName, parsed);
         const expected = "444.32 - 2232.43";
         assert.equal(actual, expected);
+        assert.deepEqual(variables, []);
     });
     test("it doesn't parse string values", () => {
-        const actual = parseExpression("\"WXSS-AS*WXSS-AS\".substring(0,1)", null);
-        const expected = "\"WXSS-AS*WXSS-AS\" .substring ( 0 , 1 )";
+        const [actual, variables] = parseExpression("\"TOTAL-QUANTITY*TOTAL-QUANTITY\".substring(0,1)", functionName, parsed);
+        const expected = "\"TOTAL-QUANTITY*TOTAL-QUANTITY\" .substring ( 0 , 1 )";
         assert.equal(actual, expected);
+        assert.deepEqual(variables, []);
+    });
+    test("it doesn't parse not found identifiers", () => {
+        const [actual, variables] = parseExpression("BLA-BLA-BLA.BLABLA * 2", functionName, parsed);
+        const expected = "BLA-BLA-BLA.BLABLA * 2";
+        assert.equal(actual, expected);
+        assert.deepEqual(variables, []);
+    });
+    test("it parses complex expressions", () => {
+        const [actual, variables] = parseExpression("\"TOTAL-QUANTITY*TOTAL-QUANTITY\".substring(0,1) + ((2*TOTAL-QUANTITY) - TOTAL-QUANTITY + WS-BILL.TOTAL-COST.length) + (TOTAL-COST.toLowerCase()) + WS-BILL.TOTAL-QUANTITY", functionName, parsed);
+        const expected = "\"TOTAL-QUANTITY*TOTAL-QUANTITY\" .substring ( 0 , 1 ) + ( ( 2 * f_15 ) - f_15 + f_16.length ) + ( f_16.toLowerCase ( ) ) + f_15";
+        assert.equal(actual, expected);
+        assert.deepEqual(variables, ["f_15", "f_16"]);
     });
 });


### PR DESCRIPTION
Adding support for expressions on WATCH panel.

The solution was:
* Find all COBOL variables from the given JavaScript-like expression:
* Replace them by the C equivalent name to avoid syntax errors;
* Add to the expression the variable values;
 * Call `eval`;

![image](https://user-images.githubusercontent.com/4491850/84207615-0c91be00-aab2-11ea-824b-bb48a06e52f2.png)
