### PR TITLE
Merging differences between branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,43 @@ Stop the container by `Ctrl+Shift+P` and command `GnuCOBOL Docker: stop`, or in 
 docker rm --force gnucobol
 ```
 
+### Attaching to a running process - EXPERIMENTAL
+You may debug your COBOL program attaching to a running process.
+
+This is an experimental feature, it doesn't display the variable values yet. For more details, please refer to [attach to a running process #3](https://github.com/OlegKunitsyn/gnucobol-debug/issues/3). 
+
+Add `pid` property to your `launch.json` and start debugging session (you can use a input variable to help like the sample below).
+
+Here's an example:
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "COBOL debugger (Attach)",
+            "type": "gdb",
+            "request": "attach",
+            "target": "${file}",
+            "targetargs": [],
+            "cwd": "${workspaceRoot}",
+            "gdbpath": "gdb",
+            "cobcpath": "cobc",
+            "cobcargs": ["-x", "-C"],
+            "group": [],
+            "coverage": false,
+            "pid": "${input:pid}"
+        }
+    ],
+    "inputs": [
+        {
+            "id": "pid",
+            "type": "promptString",
+            "description": "PID to attach"
+        }
+    ]
+}
+```
+
 ### Roadmap
 - Mac
 - Unit testing

--- a/src/mi2.ts
+++ b/src/mi2.ts
@@ -325,7 +325,12 @@ export class MI2 extends EventEmitter implements IDebugger {
 									} else {
 										if (this.verbose)
 											this.log("stderr", "Not implemented stop reason (assuming exception): " + reason);
-										this.emit("stopped", parsed);
+
+										if (!this.map.hasLineCobol(parsed.record('frame.fullname'), parseInt(parsed.record('frame.line')))) {
+											this.continue();
+										} else {
+											this.emit("stopped", parsed);
+										}
 									}
 								} else {
 									if (this.verbose)


### PR DESCRIPTION
The differences are not that much, actually, the biggest diff is related to handling stops. 

Basically, whenever GDB attachs to a running process, it stops wherever is the runtime. If that happens, the debugger has to check if it is an existing COBOL line, otherwise, it should trigger a `continue` command. 