### PR TITLE
#48 - Presenting variable details

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,19 @@
 					}
 				]
 			}
-		]
+		],
+		"configuration": {
+			"type": "object",
+			"title": "COBOL Debugger",
+			"properties": {
+				"Cobol_Debugger.display_variable_attributes": {
+					"type": "boolean",
+					"default": true,
+					"description": "Displaying Data Storages and Fields attributes(e.g. size of Alphanumerics or digits and scale of numerics).",
+					"scope": "resource"
+				}
+			}
+		}
 	},
 	"scripts": {
 		"prepublish": "tsc -p ./",

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -130,6 +130,8 @@ export class Attribute {
 			case 'numeric binary':
 				if (this.has(CobFlag.IS_POINTER)) {
 					type = "pointer";
+					details.push({ type: 'number', name: 'digits', value: `${this.digits}` });
+					break;
 				}
 			case 'numeric':
 			case 'numeric packed':
@@ -217,16 +219,18 @@ export class DebuggerVariable {
 		this.value = this.attribute.parse(value);
 	}
 
-	public toDebugProtocolVariable(): DebugProtocol.Variable[] {
+	public toDebugProtocolVariable(showDetails: boolean): DebugProtocol.Variable[] {
 		const result: DebugProtocol.Variable[] = [];
 
-		for (const detail of this.details) {
-			result.push({
-				name: detail.name,
-				type: detail.type,
-				value: detail.value,
-				variablesReference: 0
-			});
+		if (showDetails) {
+			for (const detail of this.details) {
+				result.push({
+					name: detail.name,
+					type: detail.type,
+					value: detail.value,
+					variablesReference: 0
+				});
+			}
 		}
 
 		result.push({

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -345,8 +345,7 @@ export class GDBDebugSession extends DebugSession {
 				for (const stackVariable of stackVariables) {
 					variables.push({
 						name: stackVariable.cobolName,
-						type: stackVariable.getType(),
-						value: stackVariable.getType(),
+						value: stackVariable.displayableType,
 						variablesReference: this.variableHandles.create(stackVariable.cobolName)
 					});
 				}
@@ -363,18 +362,16 @@ export class GDBDebugSession extends DebugSession {
 				// TODO: this evals on an (effectively) unknown thread for multithreaded programs.
 				const stackVariable = await this.miDebugger.evalCobField(id, 0, 0);
 
-				const variables: DebugProtocol.Variable[] = [];
-				variables.push({
-					name: 'Value',
-					type: stackVariable.getType(),
-					value: stackVariable.value || "null",
-					variablesReference: 0
-				});
+				let variables: DebugProtocol.Variable[] = [];
+
+				if (stackVariable.children.size == 0) {
+					variables = stackVariable.toDebugProtocolVariable();
+				}
+
 				for (const child of stackVariable.children.values()) {
 					variables.push({
 						name: child.cobolName,
-						type: child.getType(),
-						value: child.getType(),
+						value: child.displayableType,
 						variablesReference: this.variableHandles.create(`${id}.${child.cobolName}`)
 					});
 				}

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -17,6 +17,7 @@ import { VariableObject } from './debugger';
 import { MINode } from './parser.mi2';
 import { MI2 } from './mi2';
 import { CoverageStatus } from './coverage';
+import { DebuggerSettings } from './settings';
 
 const STACK_HANDLES_START = 1000;
 const VAR_HANDLES_START = 512 * 256 + 1000;
@@ -53,8 +54,11 @@ export class GDBDebugSession extends DebugSession {
 	protected miDebugger: MI2;
 	coverageStatus: CoverageStatus;
 	private container: string;
+	private showVariableDetails: boolean;
+	private settings = new DebuggerSettings();
 
 	protected initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments): void {
+		this.showVariableDetails = this.settings.displayVariableAttributes;
 		this.sendResponse(response);
 	}
 
@@ -365,7 +369,7 @@ export class GDBDebugSession extends DebugSession {
 				let variables: DebugProtocol.Variable[] = [];
 
 				if (stackVariable.children.size == 0) {
-					variables = stackVariable.toDebugProtocolVariable();
+					variables = stackVariable.toDebugProtocolVariable(this.showVariableDetails);
 				}
 
 				for (const child of stackVariable.children.values()) {

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -345,8 +345,8 @@ export class GDBDebugSession extends DebugSession {
 				for (const stackVariable of stackVariables) {
 					variables.push({
 						name: stackVariable.cobolName,
-						type: stackVariable.attribute.type,
-						value: stackVariable.attribute.type,
+						type: stackVariable.getType(),
+						value: stackVariable.getType(),
 						variablesReference: this.variableHandles.create(stackVariable.cobolName)
 					});
 				}
@@ -366,15 +366,15 @@ export class GDBDebugSession extends DebugSession {
 				const variables: DebugProtocol.Variable[] = [];
 				variables.push({
 					name: 'Value',
-					type: stackVariable.attribute.type,
+					type: stackVariable.getType(),
 					value: stackVariable.value || "null",
 					variablesReference: 0
 				});
 				for (const child of stackVariable.children.values()) {
 					variables.push({
 						name: child.cobolName,
-						type: child.attribute.type,
-						value: child.attribute.type,
+						type: child.getType(),
+						value: child.getType(),
 						variablesReference: this.variableHandles.create(`${id}.${child.cobolName}`)
 					});
 				}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,25 @@
+import * as vscode from 'vscode';
+
+export class DebuggerSettings {
+    private readonly settings: vscode.WorkspaceConfiguration;
+
+    constructor() {
+        this.settings = vscode.workspace.getConfiguration("Cobol_Debugger");
+    }
+
+    private getWithFallback<T>(section: string): T {
+        const info: any = this.settings.inspect<T>(section);
+        if (info.workspaceFolderValue !== undefined) {
+            return info.workspaceFolderValue;
+        } else if (info.workspaceValue !== undefined) {
+            return info.workspaceValue;
+        } else if (info.globalValue !== undefined) {
+            return info.globalValue;
+        }
+        return info.defaultValue;
+    }
+
+    public get displayVariableAttributes(): boolean {
+        return this.getWithFallback<boolean>("display_variable_attributes");
+    }
+}

--- a/test/parser.c.test.ts
+++ b/test/parser.c.test.ts
@@ -75,7 +75,7 @@ suite("C code parse", () => {
 		}
 
 		const variable = parsed.getVariableByCobol('datatypes_.numeric-data.dispp');
-		assert.equal('Numeric', variable.attribute.type);
+		assert.equal('numeric', variable.attribute.type);
 		assert.equal(8, variable.attribute.digits);
 		assert.equal(8, variable.attribute.scale);
 	});

--- a/test/parser.c.test.ts
+++ b/test/parser.c.test.ts
@@ -71,6 +71,7 @@ suite("C code parse", () => {
 			assert.notEqual(variable.attribute.digits, undefined);
 			assert.notEqual(variable.attribute.scale, null);
 			assert.notEqual(variable.attribute.scale, undefined);
+			assert.notEqual(variable.attribute.flags, undefined);
 		}
 
 		const variable = parsed.getVariableByCobol('datatypes_.numeric-data.dispp');


### PR DESCRIPTION
To provide more details to the developers, the fields will have more details. For instance if it is a numeric field, it will contain digits and scale, if the value is signed or not. If alphanumeric it will contain the size if the field, and so on.

Besides that, getting field details allowed the extension to specialize better in the available types, like pointers and bits.

Now it's available a COBOL Debugger setting, where the developer can deactivate this feature.