### PR TITLE
#54 - stop calling cob display

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -159,22 +159,21 @@ export class Attribute {
 			return null;
 		}
 		switch (this.type) {
-			case 'group':
+			case 'Group':
 				return valueStr;
-			case 'boolean':
-			case 'numeric':
-			case 'numeric binary':
-			case 'numeric packed':
-			case 'numeric float':
-			case 'numeric double':
-			case 'numeric long double':
-			case 'numeric fp dec64':
-			case 'numeric fp dec128':
-			case 'numeric fp bin32':
-			case 'numeric fp bin64':
-			case 'numeric fp bin128':
-			case 'numeric comp5':
-			case 'integer':
+			case 'Boolean':
+			case 'Numeric':
+			case 'Numeric binary':
+			case 'Numeric packed':
+			case 'Numeric float':
+			case 'Numeric double':
+			case 'Numeric long double':
+			case 'Numeric FP DEC64':
+			case 'Numeric FP DEC128':
+			case 'Numeric FP BIN32':
+			case 'Numeric FP BIN64':
+			case 'Numeric FP BIN128':
+			case 'Numeric COMP5':
 				return removeLeadingZeroes(valueStr);
 			default:
 				return `"${valueStr.trim()}"`;

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -25,6 +25,95 @@ export interface Stack {
 	line: number;
 }
 
+const repeatTimeRegex = /(\"\,\s|^)\'(\s|0)\'\s\<repeats\s(\d+)\stimes\>/i;
+export class CobolFieldDataParser {
+
+	public static parse(valueStr: string): string {
+		let value = valueStr;
+		if (value.indexOf(" ") === -1) {
+			return null;
+		}
+
+		value = value.substring(value.indexOf(" ") + 1);
+		if (value.startsWith("<")) {
+			if (value.indexOf(" ") === -1) {
+				return null;
+			}
+			value = value.substring(value.indexOf(" ") + 1);
+		}
+
+		const fieldMatch = repeatTimeRegex.exec(value);
+		if (fieldMatch) {
+			let replacement = "";
+			const size = parseInt(fieldMatch[3]);
+			for (let i = 0; i < size; i++) {
+				replacement += fieldMatch[2];
+			}
+			replacement += "\"";	
+			value = value.replace(repeatTimeRegex, replacement);	
+			if (!value.startsWith("\"")) {	
+				value = `"${value}`;	
+			}
+		}
+
+		return value;
+	}
+}
+
+export class NumericValueParser {
+
+	private static ZERO_SIGN_CHAR_CODE = 112;
+
+	public static parse(valueStr: string, fieldSize: number, scale: number): string {
+		let value = valueStr;
+		if (value.startsWith('"')) {
+			value = value.substring(1, fieldSize + 1);
+			const signCharCode = value.charCodeAt(value.length - 1);
+			let sign = "";
+			if (signCharCode >= this.ZERO_SIGN_CHAR_CODE) {
+				sign = "-";
+				value = `${value.substring(0, value.length - 1)}${signCharCode - this.ZERO_SIGN_CHAR_CODE}`
+			}
+			if (value.length < scale) {
+				const diff = scale - value.length;
+				let prefix = "";
+				for (let i = 0; i < diff; i++) {
+					prefix += "0";
+				}
+				value = prefix + value;
+			} else if (scale < 0) {
+				const diff = scale * -1;
+				let suffix = "";
+				for (let i = 0; i < diff; i++) {
+					suffix += "0";
+				}
+				value += suffix;
+			}
+			const wholeNumber = value.substring(0, value.length - scale);
+			const decimals = value.substring(value.length - scale);
+			let numericValue = `${sign}${wholeNumber}`;
+			if (decimals.length > 0) {
+				numericValue = `${numericValue}.${decimals}`;
+			}
+			return `${parseFloat(numericValue)}`;
+		}
+		return value;
+	}
+}
+
+export class AlphanumericValueParser {
+
+	public static parse(valueStr: string, fieldSize: number): string {
+		let value = valueStr;
+		let shift = 0;
+		if (value.startsWith('"')) {
+			shift = 1;
+		}
+		const size = Math.min(fieldSize + shift, valueStr.length - shift);
+		return `"${value.substring(shift, size).trim()}"`;
+	}
+}
+
 export enum CobFlag {
 	HAVE_SIGN,
 	SIGN_SEPARATE,
@@ -118,7 +207,7 @@ export class Attribute {
 		return flags;
 	}
 
-	public getDetails(size: string): [string, VariableDetail[]] {
+	public getDetails(size: number): [string, VariableDetail[]] {
 		const details: VariableDetail[] = [];
 		let type = this.type;
 
@@ -154,29 +243,27 @@ export class Attribute {
 		return [type, details];
 	}
 
-	public parse(valueStr: string): string {
+	public parse(valueStr: string, fieldSize: number): string {
+		if (!valueStr) {
+			return null;
+		}
+		if (valueStr.startsWith("0x")) {
+			valueStr = CobolFieldDataParser.parse(valueStr);
+		}
 		if (!valueStr) {
 			return null;
 		}
 		switch (this.type) {
-			case 'Group':
-				return valueStr;
-			case 'Boolean':
-			case 'Numeric':
-			case 'Numeric binary':
-			case 'Numeric packed':
-			case 'Numeric float':
-			case 'Numeric double':
-			case 'Numeric long double':
-			case 'Numeric FP DEC64':
-			case 'Numeric FP DEC128':
-			case 'Numeric FP BIN32':
-			case 'Numeric FP BIN64':
-			case 'Numeric FP BIN128':
-			case 'Numeric COMP5':
-				return removeLeadingZeroes(valueStr);
+			case 'numeric':
+				return NumericValueParser.parse(valueStr, fieldSize, this.scale);
+			case 'numeric edited':
+			case 'alphanumeric':
+			case 'alphanumeric edited':
+			case 'national':
+			case 'national edited':
+				return AlphanumericValueParser.parse(valueStr, fieldSize);
 			default:
-				return `"${valueStr.trim()}"`;
+				return valueStr;
 		}
 	}
 }
@@ -191,7 +278,7 @@ export class DebuggerVariable {
 		public cName: string,
 		public functionName: string,
 		public attribute: Attribute = null,
-		public size: string = null,
+		public size: number = null,
 		public value: string = null,
 		public parent: DebuggerVariable = null,
 		public children: Map<string, DebuggerVariable> = new Map<string, DebuggerVariable>()) {
@@ -215,7 +302,7 @@ export class DebuggerVariable {
 	}
 
 	public setValue(value: string): void {
-		this.value = this.attribute.parse(value);
+		this.value = this.attribute.parse(value, this.size);
 	}
 
 	public toDebugProtocolVariable(showDetails: boolean): DebugProtocol.Variable[] {

--- a/src/mi2.ts
+++ b/src/mi2.ts
@@ -713,9 +713,6 @@ export class MI2 extends EventEmitter implements IDebugger {
 		let value = dataResponse.result("value");
 		if (value === "0x0") {
 			value = null;
-		} else if (variable.cName.startsWith("f_")) {
-			const response = await this.sendCobFieldEvalCommand(variable.cName);
-			value = response.result("value");
 		}
 		variable.setValue(value);
 
@@ -767,19 +764,6 @@ export class MI2 extends EventEmitter implements IDebugger {
 	sendUserInput(command: string, threadId: number = 0, frameLevel: number = 0): Thenable<any> {
 		return new Promise((resolve, reject) => {
 			this.stdin(command, resolve);
-		});
-	}
-
-	sendCobFieldEvalCommand(cName: string): Thenable<MINode> {
-		return new Promise(async (resolve, reject) => {
-			const sel = this.currentToken++;
-			this.handlers[sel] = (node: MINode) => {
-				resolve(node);
-			};
-			this.stdin(
-				`call (void)printf("${sel}^done,value=|")
-				 call (void)cob_display(0,1,1,&${cName})`
-			);
 		});
 	}
 

--- a/src/parser.c.ts
+++ b/src/parser.c.ts
@@ -81,9 +81,9 @@ export class SourceMap {
 			}
 			match = dataStorageRegex.exec(line);
 			if (match) {
-				let size = "unknown";
-				if(match[3].startsWith("[")) {
-					size = match[3].substring(1, match[3].length - 1);
+				let size: number = null;
+				if (match[3].startsWith("[")) {
+					size = parseInt(match[3].substring(1, match[3].length - 1));
 				}
 				const dataStorage = new DebuggerVariable(match[4], match[2], functionName, new Attribute(null, VariableType[match[1]], 0, 0), size);
 				this.dataStorages.set(`${functionName}.${dataStorage.cName}`, dataStorage);
@@ -94,7 +94,7 @@ export class SourceMap {
 			if (match) {
 				const attribute = this.attributes.get(`${cleanedFile}.${match[4]}`);
 				const dataStorage = this.dataStorages.get(`${functionName}.${match[3]}`);
-				const field = new DebuggerVariable(match[5], match[1], functionName, attribute, match[2]);
+				const field = new DebuggerVariable(match[5], match[1], functionName, attribute, parseInt(match[2]));
 
 				if (dataStorage && dataStorage.cobolName === field.cobolName) {
 					this.variablesByC.delete(`${functionName}.${dataStorage.cName}`);

--- a/src/parser.mi2.ts
+++ b/src/parser.mi2.ts
@@ -189,12 +189,6 @@ export function parseMI(output: string): MINode {
 		return str;
 	};
 
-	const parseCobFieldValue = () => {
-		if (output[0] != '|')
-			return "";
-		return output.substr(1);
-	};
-
 	let parseValue, parseCommaResult, parseCommaValue, parseResult;
 
 	const parseTupleOrList = () => {
@@ -237,8 +231,6 @@ export function parseMI(output: string): MINode {
 			return parseCString();
 		else if (output[0] == '{' || output[0] == '[')
 			return parseTupleOrList();
-		else if (output[0] == '|')
-			return parseCobFieldValue();
 		else
 			return undefined;
 	};
@@ -315,5 +307,5 @@ export function parseMI(output: string): MINode {
 		output = output.replace(newlineRegex, "");
 	}
 
-	return new MINode(token, <any> outOfBandRecord || [], resultRecords);
+	return new MINode(token, <any>outOfBandRecord || [], resultRecords);
 }

--- a/test/parser.mi2.test.ts
+++ b/test/parser.mi2.test.ts
@@ -190,9 +190,4 @@ suite("MI Parse", () => {
 		assert.deepEqual(undefined, MINode.valueOf(variables[0], "value"));
 		assert.deepEqual('unsigned char [3]', MINode.valueOf(variables[0], "type"));
 	});
-	test("parse special cob_display event", () => {
-		const parsed = parseMI(`12^done,value=|blablabla`);
-		const value = parsed.result('value');
-		assert.equal('blablabla', value);
-	});
 });


### PR DESCRIPTION
As described on the issue #54 , some side-effects are impeding the extension to have new features.

To fix this problem, I am reverting all changes related to parsing cob_field values to an equivalent state to what was before adding `COB_DISPLAY`, where the extension was supporting alphanumeric and numeric types. All `usage` cases are not supported anymore and they are going to be handled accordingly in the future, in different issues.