### PR TITLE
#40 - Support for cob_put_field_str

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -348,6 +348,7 @@ export class DebuggerVariable {
 			for (const detail of this.details) {
 				result.push({
 					name: detail.name,
+					evaluateName: this.cobolName,
 					type: detail.type,
 					value: detail.value,
 					variablesReference: 0
@@ -357,7 +358,7 @@ export class DebuggerVariable {
 
 		result.push({
 			name: 'value',
-			type: this.displayableType,
+			evaluateName: this.cobolName,
 			value: this.value || "null",
 			variablesReference: 0
 		});

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -1,6 +1,6 @@
 import { MINode } from "./parser.mi2";
 import { DebugProtocol } from "vscode-debugprotocol/lib/debugProtocol";
-import { removeLeadingZeroes } from "./parser.expression";
+import { removeLeadingZeroes } from "./functions";
 import { SourceMap } from "./parser.c";
 
 export interface Breakpoint {

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -1,6 +1,7 @@
 import { MINode } from "./parser.mi2";
 import { DebugProtocol } from "vscode-debugprotocol/lib/debugProtocol";
 import { removeLeadingZeroes } from "./parser.expression";
+import { SourceMap } from "./parser.c";
 
 export interface Breakpoint {
 	file?: string;
@@ -49,10 +50,10 @@ export class CobolFieldDataParser {
 			for (let i = 0; i < size; i++) {
 				replacement += fieldMatch[2];
 			}
-			replacement += "\"";	
-			value = value.replace(repeatTimeRegex, replacement);	
-			if (!value.startsWith("\"")) {	
-				value = `"${value}`;	
+			replacement += "\"";
+			value = value.replace(repeatTimeRegex, replacement);
+			if (!value.startsWith("\"")) {
+				value = `"${value}`;
 			}
 		}
 
@@ -266,6 +267,37 @@ export class Attribute {
 				return valueStr;
 		}
 	}
+
+	public parseUsage(valueStr: string): string {
+		if (!valueStr) {
+			return null;
+		}
+		if (valueStr.startsWith("0x")) {
+			valueStr = CobolFieldDataParser.parse(valueStr);
+		}
+		if (!valueStr) {
+			return null;
+		}
+		switch (this.type) {
+			case 'boolean':
+			case 'numeric':
+			case 'numeric binary':
+			case 'numeric packed':
+			case 'numeric float':
+			case 'numeric double':
+			case 'numeric long double':
+			case 'numeric fp dec64':
+			case 'numeric fp dec128':
+			case 'numeric fp bin32':
+			case 'numeric fp bin64':
+			case 'numeric fp bin128':
+			case 'numeric comp5':
+			case 'integer':
+				return removeLeadingZeroes(valueStr.substring(1, valueStr.length - 1));
+			default:
+				return valueStr;
+		}
+	}
 }
 
 export class DebuggerVariable {
@@ -303,6 +335,10 @@ export class DebuggerVariable {
 
 	public setValue(value: string): void {
 		this.value = this.attribute.parse(value, this.size);
+	}
+
+	public setValueUsage(value: string): void {
+		this.value = this.attribute.parseUsage(value);
 	}
 
 	public toDebugProtocolVariable(showDetails: boolean): DebugProtocol.Variable[] {
@@ -348,9 +384,13 @@ export interface IDebugger {
 	getStack(maxLevels: number, thread: number): Thenable<Stack[]>;
 	getStackVariables(thread: number, frame: number): Thenable<DebuggerVariable[]>;
 	evalExpression(name: string, thread: number, frame: number): Thenable<any>;
+	evalCobField(name: string, thread: number, frame: number): Promise<DebuggerVariable>;
 	isReady(): boolean;
-	changeVariable(name: string, rawValue: string): Thenable<any>;
+	changeVariable(name: string, rawValue: string): Promise<any>;
 	examineMemory(from: number, to: number): Thenable<any>;
+	getGcovFiles(): string[];
+	sendUserInput(command: string, threadId: number, frameLevel: number): Thenable<any>;
+	getSourceMap(): SourceMap;
 }
 
 export class VariableObject {

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -116,3 +116,22 @@ export function parseExpression(expression: string, functionName: string, source
     checkToken(token, tokenStack, functionName, sourceMap, variableInC);
     return [tokenStack.join(" "), Array.from(variableInC)];
 }
+
+const containsQuotes = /"/g;
+export function cleanRawValue(rawValue: string): string {
+    let cleanedRawValue = rawValue;
+
+    if(!!cleanedRawValue && cleanedRawValue.startsWith("\"")) {
+        cleanedRawValue = cleanedRawValue.substring(1);
+    }
+
+    if(!!cleanedRawValue && cleanedRawValue.endsWith("\"")) {
+        cleanedRawValue = cleanedRawValue.substring(0, cleanedRawValue.length - 1);
+    }
+
+    if(containsQuotes.test(cleanedRawValue)) {
+        cleanedRawValue = cleanedRawValue.replace(containsQuotes, '\\\\\"');
+    }
+
+    return cleanedRawValue;
+}

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -75,6 +75,7 @@ export class GDBDebugSession extends DebugSession {
 
 	protected initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments): void {
 		this.showVariableDetails = this.settings.displayVariableAttributes;
+		response.body.supportsSetVariable = true;
 		this.sendResponse(response);
 	}
 
@@ -240,10 +241,19 @@ export class GDBDebugSession extends DebugSession {
 
 	protected async setVariableRequest(response: DebugProtocol.SetVariableResponse, args: DebugProtocol.SetVariableArguments): Promise<void> {
 		try {
-			await this.miDebugger.changeVariable(args.name, args.value);
-			response.body = {
-				value: args.value
-			};
+			let id: number | string | VariableObject | ExtendedVariable;
+			if (args.variablesReference < VAR_HANDLES_START) {
+				id = args.variablesReference - STACK_HANDLES_START;
+			} else {
+				id = this.variableHandles.get(args.variablesReference);
+			}
+
+			if (typeof id == "string") {
+				await this.miDebugger.changeVariable(id, args.value);
+				response.body = {
+					value: args.value
+				};
+			}
 			this.sendResponse(response);
 		} catch (err) {
 			this.sendErrorResponse(response, 11, `Could not continue: ${err}`);

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -404,6 +404,7 @@ export class GDBDebugSession extends DebugSession {
 					variables.push({
 						name: stackVariable.cobolName,
 						value: stackVariable.displayableType,
+						type: stackVariable.displayableType,
 						variablesReference: this.variableHandles.create(stackVariable.cobolName)
 					});
 				}
@@ -429,7 +430,9 @@ export class GDBDebugSession extends DebugSession {
 				for (const child of stackVariable.children.values()) {
 					variables.push({
 						name: child.cobolName,
+						evaluateName: child.cobolName,
 						value: child.displayableType,
+						type: child.displayableType,
 						variablesReference: this.variableHandles.create(`${id}.${child.cobolName}`)
 					});
 				}
@@ -490,7 +493,7 @@ export class GDBDebugSession extends DebugSession {
 
 	protected evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments): void {
 		const [threadId, level] = this.frameIdToThreadAndLevel(args.frameId);
-		if (args.context == "watch" || args.context == "hover") {
+		if (args.context == "watch" || args.context == "variables" || args.context == "hover") {
 			this.miDebugger.evalExpression(args.expression, threadId, level).then((res) => {
 				response.body = {
 					variablesReference: 0,

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -54,7 +54,7 @@ export interface AttachRequestArguments extends DebugProtocol.LaunchRequestArgum
 	group: string[];
 	verbose: boolean;
 	pid: string;
-	remoteDebugger: string; 
+	remoteDebugger: string;
 }
 
 export class GDBDebugSession extends DebugSession {
@@ -123,7 +123,7 @@ export class GDBDebugSession extends DebugSession {
 	}
 
 	protected attachRequest(response: DebugProtocol.AttachResponse, args: AttachRequestArguments): void {
-		if(!args.pid && !args.remoteDebugger) {
+		if (!args.pid && !args.remoteDebugger) {
 			this.sendErrorResponse(response, 100, `Failed to start MI Debugger: pid or remoteDebugger is mandatory`);
 			return;
 		}
@@ -240,23 +240,10 @@ export class GDBDebugSession extends DebugSession {
 
 	protected async setVariableRequest(response: DebugProtocol.SetVariableResponse, args: DebugProtocol.SetVariableArguments): Promise<void> {
 		try {
-			if (this.useVarObjects) {
-				let name = args.name;
-				if (args.variablesReference >= VAR_HANDLES_START) {
-					const parent = this.variableHandles.get(args.variablesReference) as VariableObject;
-					name = `${parent.name}.${name}`;
-				}
-
-				const res = await this.miDebugger.varAssign(name, args.value);
-				response.body = {
-					value: res.result("value")
-				};
-			} else {
-				await this.miDebugger.changeVariable(args.name, args.value);
-				response.body = {
-					value: args.value
-				};
-			}
+			await this.miDebugger.changeVariable(args.name, args.value);
+			response.body = {
+				value: args.value
+			};
 			this.sendResponse(response);
 		} catch (err) {
 			this.sendErrorResponse(response, 11, `Could not continue: ${err}`);

--- a/src/mi2.ts
+++ b/src/mi2.ts
@@ -496,9 +496,9 @@ export class MI2 extends EventEmitter implements IDebugger {
 		try {
 			const variable = this.map.getVariableByCobol(`${functionName}.${name}`);
 			if (this.hasCobPutFieldStringFunction) {
-				await this.sendCommand(`data-evaluate-expression "(int)cob_put_field_str(&${variable.cName}, \"${rawValue}\")"`);
+				await this.sendCommand(`data-evaluate-expression "(int)cob_put_field_str(&${variable.cName}, \\\"${rawValue}\\\")"`);
 			} else {
-				await this.sendCommand(`gdb-set var ${variable.cName}=\"${rawValue}\"`);
+				await this.sendCommand(`gdb-set var ${variable.cName}=\\\"${rawValue}\\\"`);
 			}
 		} catch (e) {
 			if (e.message.includes("cob_put_field_str")) {

--- a/src/mi2.ts
+++ b/src/mi2.ts
@@ -30,6 +30,8 @@ export class MI2 extends EventEmitter implements IDebugger {
 	private errbuf: string;
 	private process: ChildProcess.ChildProcess;
 	private lastStepCommand: Function;
+	private hasCobGetFieldStringFunction: boolean = true;
+	private hasCobPutFieldStringFunction: boolean = true;
 
 	constructor(public gdbpath: string, public gdbArgs: string[], public cobcpath: string, public cobcArgs: string[], procEnv: any, public verbose: boolean, public noDebug: boolean) {
 		super();
@@ -485,10 +487,28 @@ export class MI2 extends EventEmitter implements IDebugger {
 		});
 	}
 
-	changeVariable(name: string, rawValue: string): Thenable<any> {
+	async changeVariable(name: string, rawValue: string): Promise<void> {
 		if (this.verbose)
 			this.log("stderr", "changeVariable");
-		return this.sendCommand("gdb-set var " + name + "=" + rawValue);
+
+		const functionName = await this.getCurrentFunctionName();
+
+		try {
+			const variable = this.map.getVariableByCobol(`${functionName}.${name}`);
+			if (this.hasCobPutFieldStringFunction) {
+				await this.sendCommand(`data-evaluate-expression "(int)cob_put_field_str(&${variable.cName}, \"${rawValue}\")"`);
+			} else {
+				await this.sendCommand(`gdb-set var ${variable.cName}=\"${rawValue}\"`);
+			}
+		} catch (e) {
+			if (e.message.includes("cob_put_field_str")) {
+				this.hasCobPutFieldStringFunction = false;
+				return this.changeVariable(name, rawValue);
+			}
+			this.log("stderr", `Failed to set cob field value on ${functionName}.${name}`);
+			this.log("stderr", e.message);
+			throw e;
+		}
 	}
 
 	loadBreakPoints(breakpoints: Breakpoint[]): Thenable<[boolean, Breakpoint][]> {
@@ -743,13 +763,13 @@ export class MI2 extends EventEmitter implements IDebugger {
 			const variable = this.map.getVariableByCobol(`${functionName}.${name}`);
 			return await this.evalVariable(variable, thread, frame);
 		} catch (e) {
-			this.log("stderr", `Failed to set value on ${functionName}.${name}`);
+			this.log("stderr", `Failed to eval cob field value on ${functionName}.${name}`);
 			this.log("stderr", e.message);
 			throw e;
 		}
 	}
 
-	async evalVariable(variable: DebuggerVariable, thread: number, frame: number): Promise<DebuggerVariable> {
+	private async evalVariable(variable: DebuggerVariable, thread: number, frame: number): Promise<DebuggerVariable> {
 		if (this.verbose)
 			this.log("stderr", "evalVariable");
 
@@ -757,60 +777,45 @@ export class MI2 extends EventEmitter implements IDebugger {
 		if (thread != 0) {
 			command += `--thread ${thread} --frame ${frame} `;
 		}
-		command += variable.cName;
 
-		if (variable.cName.startsWith("f_")) {
-			command += ".data";
+		if (this.hasCobGetFieldStringFunction && variable.cName.startsWith("f_")) {
+			command += `"(char *)cob_get_field_str_buffered(&${variable.cName})"`;
+		} else if (variable.cName.startsWith("f_")) {
+			command += `${variable.cName}.data`;
+		} else {
+			command += variable.cName;
 		}
-		const dataResponse = await this.sendCommand(command);
-		let value = dataResponse.result("value");
-		if (value === "0x0") {
-			value = null;
+
+		let dataResponse;
+		let value = null;
+		try {
+			dataResponse = await this.sendCommand(command);
+			value = dataResponse.result("value");
+			if (value === "0x0") {
+				value = null;
+			}
+		} catch (error) {
+			if (error.message.includes("cob_get_field_str_buffered")) {
+				this.hasCobGetFieldStringFunction = false;
+				return this.evalVariable(variable, thread, frame);
+			}
+			this.log("stderr", error.message);
 		}
-		variable.setValue(value);
+
+		if (this.hasCobGetFieldStringFunction) {
+			variable.setValueUsage(value);
+		} else {
+			variable.setValue(value);
+		}
 
 		return variable;
 	}
 
-	async varCreate(expression: string, name: string = "-"): Promise<VariableObject> {
-		if (this.verbose)
-			this.log("stderr", "varCreate");
-		const res = await this.sendCommand(`var-create ${name} @ "${expression}"`);
-		return new VariableObject(res.result(""));
-	}
-
-	async varEvalExpression(name: string): Promise<MINode> {
-		if (this.verbose)
-			this.log("stderr", "varEvalExpression");
-		return this.sendCommand(`var-evaluate-expression ${name}`);
-	}
-
-	async varListChildren(name: string): Promise<VariableObject[]> {
-		if (this.verbose)
-			this.log("stderr", "varListChildren");
-		//TODO: add `from` and `to` arguments
-		const res = await this.sendCommand(`var-list-children --all-values ${name}`);
-		const children = res.result("children") || [];
-		return children.map(child => new VariableObject(child[1]));
-	}
-
-	async varUpdate(name: string = "*"): Promise<MINode> {
-		if (this.verbose)
-			this.log("stderr", "varUpdate");
-		return this.sendCommand(`var-update --all-values ${name}`);
-	}
-
-	async varAssign(name: string, rawValue: string): Promise<MINode> {
-		if (this.verbose)
-			this.log("stderr", "varAssign");
-		return this.sendCommand(`var-assign ${name} ${rawValue}`);
-	}
-
-	logNoNewLine(type: string, msg: string) {
+	private logNoNewLine(type: string, msg: string): void {
 		this.emit("msg", type, msg);
 	}
 
-	log(type: string, msg: string) {
+	private log(type: string, msg: string): void {
 		this.emit("msg", type, msg[msg.length - 1] == '\n' ? msg : (msg + "\n"));
 	}
 
@@ -820,7 +825,7 @@ export class MI2 extends EventEmitter implements IDebugger {
 		});
 	}
 
-	sendCommand(command: string, suppressFailure: boolean = false): Thenable<MINode> {
+	private sendCommand(command: string, suppressFailure: boolean = false): Thenable<MINode> {
 		return new Promise((resolve, reject) => {
 			const sel = this.currentToken++;
 			this.handlers[sel] = (node: MINode) => {

--- a/src/mi2.ts
+++ b/src/mi2.ts
@@ -31,7 +31,7 @@ export class MI2 extends EventEmitter implements IDebugger {
 	private process: ChildProcess.ChildProcess;
 	private lastStepCommand: Function;
 	private hasCobGetFieldStringFunction: boolean = true;
-	private hasCobPutFieldStringFunction: boolean = false;
+	private hasCobPutFieldStringFunction: boolean = true;
 
 	constructor(public gdbpath: string, public gdbArgs: string[], public cobcpath: string, public cobcArgs: string[], procEnv: any, public verbose: boolean, public noDebug: boolean) {
 		super();

--- a/test/functions.test.ts
+++ b/test/functions.test.ts
@@ -1,9 +1,9 @@
 import * as assert from 'assert';
 import * as nativePath from "path";
 import { SourceMap } from '../src/parser.c';
-import { parseExpression } from '../src/parser.expression';
+import { parseExpression, cleanRawValue } from '../src/functions';
 
-suite("WATCH expression parse", () => {
+suite("Useful functions", () => {
     const cwd = nativePath.resolve(__dirname, '../../test/resources');
     const c = nativePath.resolve(cwd, 'petstore.c');
     const parsed = new SourceMap(cwd, [c]);
@@ -89,6 +89,16 @@ suite("WATCH expression parse", () => {
     test("it works for -000000000000000000000001", () => {
         const [actual] = parseExpression("-000000000000000000000001", functionName, parsed);
         const expected = "-1";
+        assert.equal(actual, expected);
+    });
+    test("it removes initial and final quotes for \"tttt\"", () => {
+        const actual = cleanRawValue("\"tttt\"");
+        const expected = "tttt";
+        assert.equal(actual, expected);
+    });
+    test("it escapes internal quotes", () => {
+        const actual = cleanRawValue("\"tt\"tt\"");
+        const expected = "tt\\\\\"tt";
         assert.equal(actual, expected);
     });
 });


### PR DESCRIPTION
As part of #40 , the current changes enable the "Set Value" feature, where the developer can directly change a variable value. In order to achieve it, the extension is making use of `cob_put_field_str()`, available in the latest GC-3.1-dev.

The support for DISPLAY values on a GC 2.2 is not fully developed yet, as it requires special value treatment, especially for signed numeric values.

Setting GROUP values it is not supported yet if it doesn't have an equivalent cob_field. A parsing to an array of char may be necessary.

This PR also includes support for "Copy Value", "Copy as Expression" and "Add to Watch" for variables.

![image](https://user-images.githubusercontent.com/4491850/87096243-afb92d00-c242-11ea-8ab5-d6bcfee11382.png)

