### PR TITLE
package.json: breakpoints -> enableBreakpointsFor

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,32 +40,22 @@
 				"title": "GnuCOBOL Docker: stop"
 			}
 		],
-		"breakpoints": [
-			{
-				"language": "cobol"
-			},
-			{
-				"language": "COBOL"
-			},
-			{
-				"language": "ACUCOBOL"
-			},
-			{
-				"language": "OpenCOBOL"
-			},
-			{
-				"language": "GnuCOBOL"
-			},
-			{
-				"language": "entcobol"
-			}
-		],
 		"debuggers": [
 			{
 				"type": "gdb",
+				"label": "COBOL debugger",
+				"enableBreakpointsFor": {
+					"languageIds": [
+						"cobol",
+						"COBOL",
+						"ACUCOBOL",
+						"OpenCOBOL",
+						"GnuCOBOL",
+						"entcobol"
+					]
+				},
 				"program": "./out/src/gdb.js",
 				"runtime": "node",
-				"label": "COBOL debugger",
 				"configurationAttributes": {
 					"launch": {
 						"required": [


### PR DESCRIPTION
**untested**, looks better, used by other debugger extensions and is in line with the [debugger extensions documentation](https://vscode.readthedocs.io/en/stable/extensions/example-debuggers/).

Please test and either merge or close.