### PR TITLE
added package task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,9 +1,47 @@
 {
 	"version": "2.0.0",
-	"command": "npm",
-	"type": "shell",
-	"presentation" : { "reveal": "always", "panel": "new"},
-	"args": ["run", "compile", "--loglevel", "silent"],
-	"isBackground": true,
-	"problemMatcher": "$tsc-watch"
+	"tasks": [
+		{
+			"label": "npm",
+			"command": "npm",
+			"type": "shell",
+			"presentation": {
+				"reveal": "always",
+				"panel": "new"
+			},
+			"args": [
+				"run",
+				"compile",
+				"--loglevel",
+				"silent"
+			],
+			"isBackground": true,
+			"problemMatcher": "$tsc-watch",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		},
+		{
+			"label": "package ",
+			"command": "vsce",
+			"windows": {
+				"command": "vsce.cmd"
+			},
+			"type": "process",
+			"presentation": {
+				"reveal": "always",
+				"panel": "new"
+			},
+			"args": [
+				"package"
+			],
+			"isBackground": true,
+			"problemMatcher": "$tsc-watch",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		}
+	],
 }


### PR DESCRIPTION
Note: I've used "process" as vsce.cmd executes powershell via script which fails on a standard install. Using "process" works (I don't think that part of the MS security is really useful...)

The main reason for adding this is to be able to easily test the result on a different machine (and because F5 seems to not actually run with the extension on my machine [or at least not completely, for example doesn't bring in debug targets to add]).

We may should add a note there how to get vcse... - `npm install -g vsce` (and also how to get npm - installing it from https://nodejs.org/en/download (I've used the "zip" variant, unpacked it, started cmd.exe, executed nodenv.cmd, executed vsscodium)