### PR TITLE
restores CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 <h4 align="center">Debug COBOL code from VS Code or VSCodium.</h4>
 
 <p align="center">
+  <img src="https://img.shields.io/github/workflow/status/OlegKunitsyn/gnucobol-debug/Node.js%20CI.svg?label=Node.js%20CI" />
   <img src="https://vsmarketplacebadge.apphb.com/version/OlegKunitsyn.gnucobol-debug.svg?label=Debugger%20for%20GnuCOBOL" />
   <img src="https://vsmarketplacebadge.apphb.com/downloads-short/OlegKunitsyn.gnucobol-debug.svg?label=Downloads" />
   <img src="https://vsmarketplacebadge.apphb.com/installs-short/OlegKunitsyn.gnucobol-debug.svg?label=Installs" />


### PR DESCRIPTION
The badge was added and then removed with 0cb59bab1a3eb9ff9c66372656d02732bc6083a8 as [`osvx` blocked it](https://github.com/OlegKunitsyn/gnucobol-debug/commit/0cb59bab1a3eb9ff9c66372656d02732bc6083a8?branch=0cb59bab1a3eb9ff9c66372656d02732bc6083a8&diff=unified&short_path=04c6e90#commitcomment-41359769).

Now it is back with trusted provider shields.io which is better than direct GH badge in any case as the existing badges use the same provider and therefore the same look.

Note: you may remove the `label` attribute if you want the plain "build" instead and if you like the GH logo then you can add it with `logo=github` (I only care about the CI and therefore did not used it.