### PR TITLE
cobc and gdb on docker cannot take win32 paths as arguments.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,8 +8,8 @@ const dockerMessage = "Property 'docker' is not defined in launch.json";
 
 export function activate(context: vscode.ExtensionContext) {
     const dockerStart = vscode.commands.registerCommand('gnucobol-debug.dockerStart', function () {
-        const workspaceRoot: string = vscode.workspace.workspaceFolders[0].uri.fsPath;
         let config: vscode.DebugConfiguration;
+        var workspaceRoot: string = vscode.workspace.workspaceFolders[0].uri.fsPath;
         for (config of vscode.workspace.getConfiguration('launch', vscode.workspace.workspaceFolders[0].uri).get('configurations') as []) {
             if (config.type !== 'gdb') {
                 continue;
@@ -18,6 +18,13 @@ export function activate(context: vscode.ExtensionContext) {
                 vscode.window.showInformationMessage(dockerMessage);
                 break;
             }
+            if(process.platform === "win32") {
+                workspaceRoot = workspaceRoot
+                    .replace(/.*:/,s => "/" + s.toLowerCase().replace(":",""))
+                    .replace(/\\/g,"/");
+            }
+            vscode.workspace.workspaceFolders[0].uri.fsPath
+                .replace(/.*:/,s => "/" + s.toLowerCase().replace(":","")).replace(/\\/g,"/")
             dockerTerminal.show(true);
             dockerTerminal.sendText(`docker run -d -i --name gnucobol -w ${workspaceRoot} -v ${workspaceRoot}:${workspaceRoot} ${config.docker}`);
             break;

--- a/src/mi2.ts
+++ b/src/mi2.ts
@@ -2,10 +2,39 @@ import { Breakpoint, IDebugger, MIError, Stack, Thread, DebuggerVariable, Variab
 import * as ChildProcess from "child_process";
 import { EventEmitter } from "events";
 import { MINode, parseMI } from './parser.mi2';
-import * as nativePath from "path";
+import * as nativePathFromPath from "path";
 import * as fs from "fs";
 import { SourceMap } from "./parser.c";
 import { parseExpression, cleanRawValue } from "./functions";
+
+const nativePath = {
+	resolve: function(...args: string[]): string {
+		let nat = nativePathFromPath.resolve(...args);
+		if(process.platform === "win32") {
+			return nat.replace(/.*:/,s => "/" + s.toLowerCase().replace(":","")).replace(/\\/g,"/");
+		}
+		return nat;
+	},
+	dirname: function(path: string): string {
+		let nat = nativePathFromPath.dirname(path);
+		if(process.platform === "win32") {
+			return nat.replace(/.*:/,s => "/" + s.toLowerCase().replace(":","")).replace(/\\/g,"/");
+		}
+		return nat;
+	},
+	basename: function(path: string): string {
+		return nativePathFromPath.basename(path);
+	},
+	isAbsolute: function(path: string): boolean {
+		return nativePathFromPath.isAbsolute(path);
+	},
+	join: function(...args: string[]) {
+		return nativePathFromPath.join(...args);
+	},
+	normalize: function(path: string) {
+		return nativePathFromPath.normalize(path);
+	}
+}
 
 const nonOutput = /(^(?:\d*|undefined)[\*\+\-\=\~\@\&\^])([^\*\+\-\=\~\@\&\^]{1,})/;
 const gdbRegex = /(?:\d*|undefined)\(gdb\)/;
@@ -57,10 +86,8 @@ export class MI2 extends EventEmitter implements IDebugger {
 	}
 
 	load(cwd: string, target: string, targetargs: string, group: string[]): Thenable<any> {
-		if (!nativePath.isAbsolute(target))
-			target = nativePath.join(cwd, target);
-		if(this.cobcpath === "docker" && this.gdbpath === "docker" && process.platform === "win32")
-			target = target.replace(/.*:/,s => "/" + s.toLowerCase().replace(":","")).replace(/\\/g,"/");
+		if (!nativePath.isAbsolute(target) || (this.cobcpath === "docker" && this.gdbpath === "docker"))
+			target = nativePath.resolve(cwd, target);
 		group.forEach(e => { e = nativePath.join(cwd, e); });
 
 		return new Promise((resolve, reject) => {
@@ -123,7 +150,7 @@ export class MI2 extends EventEmitter implements IDebugger {
 				}
 
 				target = nativePath.resolve(cwd, nativePath.basename(target));
-				if (process.platform === "win32") {
+				if (process.platform === "win32" && this.cobcpath !== "docker" && this.gdbpath !== "docker") {
 					target = target.split('.').slice(0, -1).join('.') + '.exe';
 				} else {
 					target = target.split('.').slice(0, -1).join('.');
@@ -208,6 +235,10 @@ export class MI2 extends EventEmitter implements IDebugger {
 	protected initCommands(target: string, targetargs: string, cwd: string) {
 		if (!nativePath.isAbsolute(target))
 			target = nativePath.join(cwd, target);
+		if(process.platform === "win32") {
+			cwd = nativePath.dirname(target);
+		}
+
 		const cmds = [
 			this.sendCommand("gdb-set target-async on", false),
 			this.sendCommand("gdb-set print repeats 1000", false),

--- a/src/mi2.ts
+++ b/src/mi2.ts
@@ -59,6 +59,8 @@ export class MI2 extends EventEmitter implements IDebugger {
 	load(cwd: string, target: string, targetargs: string, group: string[]): Thenable<any> {
 		if (!nativePath.isAbsolute(target))
 			target = nativePath.join(cwd, target);
+		if(this.cobcpath === "docker" && this.gdbpath === "docker" && process.platform === "win32")
+			target = target.replace(/.*:/,s => "/" + s.toLowerCase().replace(":","")).replace(/\\/g,"/");
 		group.forEach(e => { e = nativePath.join(cwd, e); });
 
 		return new Promise((resolve, reject) => {


### PR DESCRIPTION
When the plugin is used on a windows computer with the docker image running, win32 style paths break cobc and gdb. This fixes cobc, I tried to make it unintrusive by checking if docker and win32 were both used before fixing the path. I could not fix gdb yet, that problem seems to be much more complex because of SourceMap. I am sure there is a better way to accomplish this, this is just proof that there is a bug and a fix.