### PR TITLE
Line.toString adjusted to source format

### DIFF
--- a/src/parser.c.ts
+++ b/src/parser.c.ts
@@ -45,7 +45,7 @@ export class Line {
     }
 
     public toString(): string {
-        return `${this.fileCobol} ${this.lineCobol} > ${this.fileC} ${this.lineC}`;
+        return `${this.fileCobol}:${this.lineCobol} > ${this.fileC}:${this.lineC}`;
     }
 }
 


### PR DESCRIPTION
file:line allows a clickable link to the actual source line (or at least it should, I haven't tested the result myself as I don't have a dev-envrionment here).