### PR TITLE
allow untrusted workspaces to be debugged

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"debug",
 		"code coverage"
 	],
-	"version": "2.31.35",
+	"version": "2.31.36",
 	"publisher": "OlegKunitsyn",
 	"license": "GPL-3.0",
 	"icon": "icon.png",
@@ -28,6 +28,11 @@
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/OlegKunitsyn/gnucobol-debug.git"
+	},
+ 	"capabilities": {
+		"untrustedWorkspaces": {
+			"supported": true
+		}
 	},
 	"contributes": {
 		"commands": [


### PR DESCRIPTION
Per "guidance for debug extensions" as noted in the [Workspace Trust Extension Guide](https://github.com/microsoft/vscode/issues/120251#issuecomment-825832603).
It _may_ be reasonable to specify "limited" if the docker commands should not be available in untrusted workspaces (aka "something you've just opened from the internet") - but that's not my decision to make, this change will make the extension to not be auto-disabled if the trust was not explicit specified before.