### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 <h4 align="center">Debug COBOL code from VS Code or VSCodium.</h4>
 
 <p align="center">
-  <img src="https://img.shields.io/github/workflow/status/OlegKunitsyn/gnucobol-debug/Node.js%20CI.svg?label=Node.js%20CI" />
   <img src="https://img.shields.io/github/v/tag/OlegKunitsyn/gnucobol-debug" />
   <img src="https://img.shields.io/visual-studio-marketplace/d/OlegKunitsyn.gnucobol-debug" />
   <img src="https://img.shields.io/visual-studio-marketplace/i/OlegKunitsyn.gnucobol-debug" />


### PR DESCRIPTION
drop duplicated (and non-working) badge

Note: you may consider to drop the GitHub created one and use the working shields.io; that would be   <img src="https://img.shields.io/github/actions/workflow/status/OlegKunitsyn/gnucobol-debug/nodejs.yml" />
`<img src="https://img.shields.io/github/actions/workflow/status/OlegKunitsyn/gnucobol-debug/nodejs.yml" />` see https://shields.io/badges/git-hub-workflow-status-with-event for options to adjust it
